### PR TITLE
Camera, location, and Instagram metadata for Photos

### DIFF
--- a/src/components/camera-icons.tsx
+++ b/src/components/camera-icons.tsx
@@ -1,0 +1,34 @@
+// Hand-drawn lucide-style icons for the two cameras these photos get shot on:
+// an iPhone 17 Pro Max (camera plateau up top) and a Sony FX30 (boxy cinema body).
+import { type SVGProps } from "react";
+
+const base = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+export function IPhoneProIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...base} {...props}>
+      <rect x="7" y="2" width="10" height="20" rx="2.5" />
+      <rect x="9.5" y="5" width="5" height="2.6" rx="1.3" />
+      <path d="M11 19h2" />
+    </svg>
+  );
+}
+
+export function SonyFX30Icon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...base} {...props}>
+      <rect x="2" y="8" width="13" height="10" rx="2" />
+      <circle cx="18.5" cy="13" r="3.5" />
+      <circle cx="18.5" cy="13" r="1.2" />
+      <path d="M5 8V6.5A1.5 1.5 0 0 1 6.5 5h3A1.5 1.5 0 0 1 11 6.5V8" />
+      <circle cx="5.5" cy="12.5" r="0.6" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/src/components/camera-icons.tsx
+++ b/src/components/camera-icons.tsx
@@ -1,12 +1,15 @@
-// Hand-drawn lucide-style icons for the two cameras these photos get shot on:
-// an iPhone 17 Pro Max (camera plateau up top) and a Sony FX30 (boxy cinema body).
+// Hand-drawn icons for the two cameras these photos get shot on, drawn from
+// product photos: an iPhone 17 Pro Max from the back (full-width camera
+// plateau, triangular three-lens cluster, flash) and a Sony FX30 from the
+// front (boxy cinema body, big E-mount ring, grip seam, top dials, REC dot).
+// Slightly finer stroke than lucide so the detail stays legible at 14px.
 import { type SVGProps } from "react";
 
 const base = {
   viewBox: "0 0 24 24",
   fill: "none",
   stroke: "currentColor",
-  strokeWidth: 2,
+  strokeWidth: 1.75,
   strokeLinecap: "round" as const,
   strokeLinejoin: "round" as const,
 };
@@ -14,9 +17,16 @@ const base = {
 export function IPhoneProIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg {...base} {...props}>
-      <rect x="7" y="2" width="10" height="20" rx="2.5" />
-      <rect x="9.5" y="5" width="5" height="2.6" rx="1.3" />
-      <path d="M11 19h2" />
+      {/* body, back view */}
+      <rect x="6" y="2" width="12" height="20" rx="3" />
+      {/* camera plateau */}
+      <rect x="7.9" y="4.1" width="8.2" height="5.9" rx="2" />
+      {/* lens cluster: two stacked left, one offset center-right */}
+      <circle cx="10.2" cy="5.95" r="1" fill="currentColor" stroke="none" />
+      <circle cx="10.2" cy="8.15" r="1" fill="currentColor" stroke="none" />
+      <circle cx="13.3" cy="7.05" r="1" fill="currentColor" stroke="none" />
+      {/* flash */}
+      <circle cx="14.95" cy="5.45" r="0.45" fill="currentColor" stroke="none" />
     </svg>
   );
 }
@@ -24,11 +34,18 @@ export function IPhoneProIcon(props: SVGProps<SVGSVGElement>) {
 export function SonyFX30Icon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg {...base} {...props}>
-      <rect x="2" y="8" width="13" height="10" rx="2" />
-      <circle cx="18.5" cy="13" r="3.5" />
-      <circle cx="18.5" cy="13" r="1.2" />
-      <path d="M5 8V6.5A1.5 1.5 0 0 1 6.5 5h3A1.5 1.5 0 0 1 11 6.5V8" />
-      <circle cx="5.5" cy="12.5" r="0.6" fill="currentColor" stroke="none" />
+      {/* boxy body, front view */}
+      <rect x="2.5" y="5.75" width="19" height="13.5" rx="2.2" />
+      {/* top dial and button */}
+      <path d="M5.4 5.75V4.6a1 1 0 0 1 1-1h1.7a1 1 0 0 1 1 1v1.15" />
+      <path d="M14.5 5.75v-.9a.9.9 0 0 1 .9-.9h1.2a.9.9 0 0 1 .9.9v.9" />
+      {/* E-mount ring and sensor */}
+      <circle cx="14.7" cy="12.5" r="4.5" />
+      <circle cx="14.7" cy="12.5" r="2.1" strokeWidth="1.5" />
+      {/* grip seam */}
+      <path d="M5.6 8.6v7.8" />
+      {/* REC button */}
+      <circle cx="19.6" cy="17.2" r="0.7" fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -29,90 +29,212 @@ export const currently = [
   { label: "Working on", text: "Wrapping an AI ops contract at G2i. Open to what's next.", to: "/work" },
 ];
 
-export type PhotoSeries = "Misc" | "Colombia" | "Spider" | "Peru";
+export type PhotoCamera = "iPhone" | "Sony";
+
+export const cameraLabels: Record<PhotoCamera, string> = {
+  iPhone: "Shot on iPhone",
+  Sony: "Shot on Sony",
+};
 
 export type Photo = {
   src: string;
   alt: string;
-  series: PhotoSeries;
+  camera: PhotoCamera;
+  location: string;
   title?: string;
   caption?: string;
   story?: string;
+  instagram?: string;
   featured?: boolean;
 };
 
 export const photos: Photo[] = [
-  { src: "/photos/misc-dsc04006.png", alt: "Ripples on dark water catching low sunlight", series: "Misc", title: "Still frame", featured: true },
-  { src: "/photos/colombia-messcam-4794.png", alt: "A woman with curly hair smiling on a high-rise balcony, mountains hazy behind her", series: "Colombia" },
+  {
+    src: "/photos/misc-dsc04006.png",
+    alt: "Ripples on dark water catching low sunlight",
+    camera: "Sony",
+    location: "Leland, NC",
+    title: "An inviting lake.",
+    story: "The lake just behind my house on a breezy day.",
+    instagram: "https://www.instagram.com/p/DBysdFoO3MT/",
+    featured: true,
+  },
+  {
+    src: "/photos/colombia-messcam-4794.png",
+    alt: "A woman with curly hair smiling on a high-rise balcony, mountains hazy behind her",
+    camera: "Sony",
+    location: "Medellin, Colombia",
+    title: "A foreign friend.",
+    story: "One of the many beautiful people I met in Colombia. Turned out to be an impromptu photoshoot.",
+    instagram: "https://www.instagram.com/p/DUzEsdQDK-U/?img_index=1",
+  },
   {
     src: "/photos/spider-img-6545.png",
     alt: "A momma wolf spider photographed up close",
-    series: "Spider",
+    camera: "iPhone",
+    location: "Leland, NC",
     title: "Momma Wolfy",
     story: "A momma wolf spider I saw and just _had_ to photograph. This shoot required a focus merge to be able to get so close and still have the entire spider in focus. It was probably the most difficult photoshoot I have done to date. Shot on my iPhone 13 Pro Max.",
+    instagram: "https://www.instagram.com/reel/CjihZjftaKs/",
   },
   {
     src: "/photos/misc-nicole.png",
     alt: "Nicole flexing her biceps at Kure Beach",
-    series: "Misc",
+    camera: "Sony",
+    location: "Kure Beach, NC",
     title: "Nicole",
     caption: "Ocean light",
     story: "My friend Nicole flexing her biceps at Kure Beach.",
+    instagram: "https://www.instagram.com/reel/C_rZMf-NWWL/",
   },
-  { src: "/photos/misc-img-1808.png", alt: "A handstand on parallette bars in a driveway, trees in the background", series: "Misc" },
+  {
+    src: "/photos/misc-img-1808.png",
+    alt: "A handstand on parallette bars in a driveway, trees in the background",
+    camera: "Sony",
+    location: "Leland, NC",
+    title: "Calisthenics & I.",
+    story: "One of my many fitness goals is a handstand pushup. Haven’t quite got it yet, but I am always trying for it.",
+  },
   {
     src: "/photos/peru-img-1130.png",
     alt: "Justin and Keiryan before leaving an Airbnb in Cusco, Peru",
-    series: "Peru",
+    camera: "Sony",
+    location: "Cusco, Peru",
     title: "Twinergy",
     story: "Justin (one of my close friends) and I just before we left our 2nd Airbnb in Cusco, Peru.",
+    instagram: "https://www.instagram.com/p/DB_3ZYEygVh/",
     featured: true,
   },
-  { src: "/photos/misc-dsc07075.png", alt: "Portrait of a man wearing sunglasses near a bridge", series: "Misc", title: "In motion" },
-  { src: "/photos/spider-img-6569.png", alt: "A wolf spider in the grass, her back covered in spiderlings", series: "Spider" },
-  { src: "/photos/misc-img-1823.png", alt: "A handstand on parallettes in the middle of a baseball diamond", series: "Misc" },
-  { src: "/photos/colombia-messcam-4797.png", alt: "A woman in a blue dress dancing on a balcony above a sprawling city skyline", series: "Colombia" },
-  { src: "/photos/misc-img-9755.png", alt: "A jet crossing an overcast sky, contrail trailing behind", series: "Misc" },
+  {
+    src: "/photos/misc-dsc07075.png",
+    alt: "Portrait of a man wearing sunglasses near a bridge",
+    camera: "Sony",
+    location: "Miami, FL",
+    title: "In motion",
+    story: "A guy Justin and I encountered in our travels in Miami. His name was “Nick”. I thought his vibe was such an aesthetic I had to ask him for a photoshoot. Very impromptu.",
+    instagram: "https://www.instagram.com/reel/CjihZjftaKs/",
+  },
+  {
+    src: "/photos/spider-img-6569.png",
+    alt: "A wolf spider in the grass, her back covered in spiderlings",
+    camera: "iPhone",
+    location: "Leland, NC",
+    title: "Momma Wolfy II",
+    story: "Another shot of mama bear holding her babies.",
+    instagram: "https://www.instagram.com/reel/CjihZjftaKs/",
+  },
+  {
+    src: "/photos/misc-img-1823.png",
+    alt: "A handstand on parallettes in the middle of a baseball diamond",
+    camera: "Sony",
+    location: "Leland, NC",
+    title: "Calisthenics & I Pt. II",
+    story: "One of my many fitness goals is a handstand pushup. Haven’t quite got it yet, but I am always trying for it.",
+  },
+  {
+    src: "/photos/colombia-messcam-4797.png",
+    alt: "A woman in a blue dress dancing on a balcony above a sprawling city skyline",
+    camera: "Sony",
+    location: "Medellin, Colombia",
+    title: "A foreign friend II",
+    story: "One of the many beautiful people I met in Colombia. Turned out to be an impromptu photoshoot.",
+    instagram: "https://www.instagram.com/p/DUzEsdQDK-U/",
+  },
+  {
+    src: "/photos/misc-img-9755.png",
+    alt: "A jet crossing an overcast sky, contrail trailing behind",
+    camera: "iPhone",
+    location: "Leland, NC",
+    title: "On Cloud 9",
+    story: "A plane traveling through the clouds over my house.",
+    instagram: "https://www.instagram.com/p/C-A4BSLOXxa/",
+  },
   {
     src: "/photos/misc-img-9751.png",
     alt: "Plane cutting through heavy clouds",
-    series: "Misc",
+    camera: "iPhone",
+    location: "Leland, NC",
     title: "Through the clouds",
     story: "Shot on iPhone 15 Pro Max.",
+    instagram: "https://www.instagram.com/p/C-A4BSLOXxa/",
   },
   {
     src: "/photos/misc-img-0312.png",
     alt: "Portrait of Keiryan smiling outdoors with a backpack",
-    series: "Misc",
-    title: "Somewhere green",
+    camera: "Sony",
+    location: "Miami, FL",
+    title: "Miami just before Peru.",
     story: "Standing in Miami with Justin just before boarding our flights to Peru.",
   },
-  { src: "/photos/spider-img-6582.png", alt: "Macro close-up of a wolf spider's face, spiderlings riding on her back", series: "Spider" },
+  {
+    src: "/photos/spider-img-6582.png",
+    alt: "Macro close-up of a wolf spider's face, spiderlings riding on her back",
+    camera: "iPhone",
+    location: "Leland, NC",
+    title: "Mama Wolfy III",
+    story: "Another shot of mama bear holding her babies.",
+    instagram: "https://www.instagram.com/reel/CjihZjftaKs/",
+  },
   {
     src: "/photos/peru-img-0133.png",
     alt: "Sunset over the beach in Peru",
-    series: "Peru",
+    camera: "Sony",
+    location: "Lima, Peru",
     title: "Sunset at La Playa",
     story: "A gorgeous burn of a sunset at the beach in Peru.",
   },
-  { src: "/photos/misc-dsc07909.png", alt: "Black-and-white street portrait of a man resting on marble steps outside a storefront", series: "Misc" },
-  { src: "/photos/spider-img-6621.png", alt: "A wolf spider facing the camera head-on, eyes in sharp focus", series: "Spider" },
+  {
+    src: "/photos/misc-dsc07909.png",
+    alt: "Black-and-white street portrait of a man resting on marble steps outside a storefront",
+    camera: "Sony",
+    location: "Lima, Peru",
+    title: "The streets of Peru.",
+    story: "The reality of the streets of Lima, Peru.",
+    instagram: "https://www.instagram.com/p/DCKUlSiSBD2/",
+  },
+  {
+    src: "/photos/spider-img-6621.png",
+    alt: "A wolf spider facing the camera head-on, eyes in sharp focus",
+    camera: "iPhone",
+    location: "Leland, NC",
+    title: "Mama Wolfy IV",
+    story: "Another shot of mama bear holding her babies.",
+    instagram: "https://www.instagram.com/reel/CjihZjftaKs/",
+  },
   {
     src: "/photos/misc-ben-2.png",
     alt: "A campfire with friends in Georgia",
-    series: "Misc",
+    camera: "Sony",
+    location: "Dallas, GA",
     title: "A fire with friends",
     story: "A scene from a campfire with friends in Georgia.",
+    instagram: "https://www.instagram.com/p/DCCbFdkvzN0/",
   },
   {
     src: "/photos/misc-img-9612.png",
     alt: "Night street scene outside a storefront in Los Angeles",
-    series: "Misc",
+    camera: "iPhone",
+    location: "Los Angeles, CA",
     title: "A night in LA",
-    story: "LA is often painted as very glamorous in Hollywood. I guess that’s because it is Hollywood. The reality off-screen is very different, however, and a night spent walking through LA will quickly teach you that.",
+    story: "LA is often painted as very glamorous in Hollywood. I guess that's because it is Hollywood. The reality off-screen is very different, however, and a night spent walking through LA will quickly teach you that.",
+    instagram: "https://www.instagram.com/p/DCFIbrIyd_l/",
   },
-  { src: "/photos/misc-img-4418.png", alt: "A smiling man with FPV drone goggles pushed up on his forehead, green field behind him", series: "Misc" },
-  { src: "/photos/misc-img-0226.png", alt: "Golden wild grass catching the afternoon sun", series: "Misc" },
+  {
+    src: "/photos/misc-img-4418.png",
+    alt: "A smiling man with FPV drone goggles pushed up on his forehead, green field behind him",
+    camera: "Sony",
+    location: "Leland, NC",
+    title: "Me flying FPV.",
+    story: "BTS of me flying my drone. One of my many hobbies.",
+  },
+  {
+    src: "/photos/misc-img-0226.png",
+    alt: "Golden wild grass catching the afternoon sun",
+    camera: "iPhone",
+    location: "Los Angeles, CA",
+    title: "Sunset in LA",
+    story: "Some plants right outside of a stadium in LA.",
+  },
 ];
 
 export type WorkRole = {

--- a/src/pages/Photos.tsx
+++ b/src/pages/Photos.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
+import { Instagram, MapPin } from "lucide-react";
 import { Layout } from "@/components/layout";
+import { IPhoneProIcon, SonyFX30Icon } from "@/components/camera-icons";
 import { Markdown } from "@/components/markdown";
 import { Reveal } from "@/components/reveal";
 import {
@@ -8,7 +10,30 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { photos, type Photo } from "@/lib/data";
+import { cameraLabels, photos, type Photo } from "@/lib/data";
+
+function CameraIcon({ photo, className }: { photo: Photo; className?: string }) {
+  return photo.camera === "iPhone" ? (
+    <IPhoneProIcon className={className} aria-hidden="true" />
+  ) : (
+    <SonyFX30Icon className={className} aria-hidden="true" />
+  );
+}
+
+// Icon-first pill: shows just the icon until hovered, then widens to reveal its label.
+function MetaChip({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <span
+      title={label}
+      className="group/chip pointer-events-auto inline-flex items-center rounded-full border border-white/15 bg-black/60 p-1.5 text-white backdrop-blur-md"
+    >
+      {icon}
+      <span className="max-w-0 overflow-hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-[0.14em] opacity-0 transition-[max-width,margin,opacity] duration-300 group-hover/chip:ml-1.5 group-hover/chip:mr-1 group-hover/chip:max-w-[12rem] group-hover/chip:opacity-100">
+        {label}
+      </span>
+    </span>
+  );
+}
 
 const Photos = () => {
   const [selectedPhoto, setSelectedPhoto] = useState<Photo | null>(null);
@@ -38,11 +63,12 @@ const Photos = () => {
                 />
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 via-black/30 to-transparent p-4 pt-12 opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100">
                   <p className="font-display text-lg font-semibold leading-tight text-white">
-                    {photo.title ?? photo.caption ?? photo.series}
+                    {photo.title ?? photo.location}
                   </p>
-                  <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.16em] text-white/70">
-                    {photo.series}
-                  </p>
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                    <MetaChip icon={<CameraIcon photo={photo} className="h-3.5 w-3.5" />} label={cameraLabels[photo.camera]} />
+                    <MetaChip icon={<MapPin className="h-3.5 w-3.5" aria-hidden="true" />} label={photo.location} />
+                  </div>
                 </div>
               </button>
             </Reveal>
@@ -67,12 +93,19 @@ const Photos = () => {
                   className="relative max-h-[58vh] w-full object-contain lg:max-h-[92vh]"
                 />
               </div>
-              <div className="min-h-0 overflow-y-auto p-6 md:p-8">
-                <div className="mb-5 inline-flex rounded-full border border-border bg-muted px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
-                  {selectedPhoto.series}
+              <div className="flex min-h-0 flex-col overflow-y-auto p-6 md:p-8">
+                <div className="mb-5 flex flex-wrap gap-2">
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                    <CameraIcon photo={selectedPhoto} className="h-3.5 w-3.5" />
+                    {cameraLabels[selectedPhoto.camera]}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                    <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                    {selectedPhoto.location}
+                  </span>
                 </div>
                 <DialogTitle className="font-display text-3xl font-semibold leading-tight">
-                  {selectedPhoto.title ?? selectedPhoto.series}
+                  {selectedPhoto.title ?? selectedPhoto.location}
                 </DialogTitle>
                 <DialogDescription className={selectedPhoto.caption ? "mt-3 text-base leading-relaxed" : "sr-only"}>
                   {selectedPhoto.caption ?? selectedPhoto.alt}
@@ -86,6 +119,19 @@ const Photos = () => {
                     // story coming soon
                   </p>
                 )}
+                {selectedPhoto.instagram ? (
+                  <div className="mt-6 flex justify-end">
+                    <a
+                      href={selectedPhoto.instagram}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label="View this photo on Instagram"
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      <Instagram className="h-4 w-4" />
+                    </a>
+                  </div>
+                ) : null}
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
Implements the photo-inventory spreadsheet changes:

- **Data**: series replaced by `camera` ("iPhone" | "Sony") + `location`; all 21 photos get their new titles and stories, and 15 get Instagram permalinks (tracking params stripped).
- **Icons**: hand-drawn lucide-style SVGs — an iPhone 17 Pro Max (camera plateau) and a Sony FX30 (boxy cinema body + lens).
- **Grid hover**: the scrim now shows icon-only chips (camera + location pin); hovering a chip expands it to reveal the text. Clicking anywhere still opens the lightbox.
- **Lightbox**: labeled camera + location chips above the title, Instagram icon at the bottom right of the story panel linking to the post.

Judgment calls (flag if wrong):
- "In motion" was listed as "Miami, NC" in the sheet → used **Miami, FL**.
- Chip text says "Shot on iPhone" / "Shot on Sony" without model names, since e.g. Momma Wolfy's story says iPhone **13** Pro Max — only the icon styling references the 17 Pro Max / FX30.

Stacked on `lego-loop` (#8); merge order: voice-and-polish → #7 → #8 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)