### PR TITLE
Blur the Lego ground shadow and fix its right-edge clipping

### DIFF
--- a/src/components/lego-loop.tsx
+++ b/src/components/lego-loop.tsx
@@ -61,8 +61,13 @@ export function LegoLoop() {
           .lego-drop { animation: none; }
         }
       `}</style>
-      <svg viewBox="-52 -100 172 188" width="280" height="306" aria-hidden="true">
-        <ellipse cx={38} cy={72} rx={86} ry={13} fill="currentColor" opacity={0.08} />
+      <svg viewBox="-60 -100 196 198" width="280" height="283" aria-hidden="true">
+        <defs>
+          <filter id="lego-shadow-blur" x="-15%" y="-100%" width="130%" height="300%">
+            <feGaussianBlur stdDeviation="3" />
+          </filter>
+        </defs>
+        <ellipse cx={38} cy={72} rx={86} ry={13} fill="currentColor" opacity={0.1} filter="url(#lego-shadow-blur)" />
         <Brick colors={blue} />
         <g transform={`translate(${offsetX} ${offsetY})`}>
           <g className="lego-drop">


### PR DESCRIPTION
Two small fixes to the Lego loop's ground shadow:

- **Blur**: the ellipse now runs through an SVG `feGaussianBlur`, so it reads as a soft ambient shadow instead of a hard-edged disc. Opacity bumped 0.08 → 0.1 to keep the same visual weight.
- **Clipping**: the shadow extended to x=124 but the viewBox ended at x=120, slicing its right edge flat. The canvas is now sized to fit the shadow plus blur spread on all sides.

Verified in both themes in the dev preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)